### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://mashie.visualstudio.com/0ae759d0-b77b-4537-8bc3-e398151a2cc6/4227aec5-4fa7-4da8-b16c-a5d9ebc99ab2/_apis/work/boardbadge/087d01ee-8ce7-42cc-a17e-50e7164b25a2)](https://mashie.visualstudio.com/0ae759d0-b77b-4537-8bc3-e398151a2cc6/_boards/board/t/4227aec5-4fa7-4da8-b16c-a5d9ebc99ab2/Microsoft.RequirementCategory)
 # github-issues


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#20638](https://mashie.visualstudio.com/0ae759d0-b77b-4537-8bc3-e398151a2cc6/_workitems/edit/20638). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.